### PR TITLE
overall fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This package includes the following services:
 
   - Uses VictoriaMetrics to send performance metrics to a remote Pushgateway.
 
-  - Configuration is handled through templates in `/config/gnosis/`, and the main config file (`vmagent.yml`) is dynamically generated based on environment variables.
+  - Configuration is handled via the config file `/config/gnosis/vmagent.yml`, placehoders in that file are automatically picked up from the environment by vmagent.
 
 ### Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     build:
       context: shutter
       args:
-        ASSETS_VERSION: shutter-gnosis-1000-set-1v2 # $NETWORK-10*$CHAIN_ID-set-$VERSION
-        UPSTREAM_VERSION: gnosis-v1.2.4b1
+        ASSETS_VERSION: shutter-gnosis-1000-set1.3 # $NETWORK-10*$CHAIN_ID-set-$VERSION
+        UPSTREAM_VERSION: v1.2.5
         KEYPER_CONFIG_DIR: /keyper/config
         SHUTTER_CHAIN_DIR: /chain
         STAKER_SCRIPTS_VERSION: v0.1.0
@@ -31,7 +31,7 @@ services:
     build:
       context: metrics
       args:
-        ASSETS_VERSION: shutter-gnosis-1000-set-1v2 # $NETWORK-10*$CHAIN_ID-set-$VERSION
+        ASSETS_VERSION: shutter-gnosis-1000-set1.3 # $NETWORK-10*$CHAIN_ID-set-$VERSION
     restart: on-failure
     environment:
       SHUTTER_PUSH_METRICS_ENABLED: false

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -9,7 +9,6 @@ FROM victoriametrics/vmagent:v1.101.0
 ARG NETWORK
 
 ENV ASSETS_DIR=/assets \
-    TEMPLATE_CONFIG_FILE=/config/${NETWORK}/vmagent_template.yml \
     CONFIG_FILE=/config/${NETWORK}/vmagent.yml \
     USER_SETTINGS_FILE=/config/user/settings.env
 

--- a/metrics/config/gnosis/vmagent.yml
+++ b/metrics/config/gnosis/vmagent.yml
@@ -6,18 +6,24 @@ scrape_configs:
     static_configs:
       - targets: ["shutter.shutter-gnosis.dappnode:9100"]
         labels:
-          instance: "%{KEYPER_NAME}"
+          instance: "kpr-%{KEYPER_NAME}"
           deployment: "%{_ASSETS_VERSION}"
+          deployment_type: "dappnode"
+          network: "%{_ASSETS_NETWORK}"
   - job_name: 'shuttermint'
     metrics_path: /
     static_configs:
       - targets: ["shutter.shutter-gnosis.dappnode:26660"]
         labels:
-          instance: "%{KEYPER_NAME}"
+          instance: "kpr-%{KEYPER_NAME}"
           deployment: "%{_ASSETS_VERSION}"
+          deployment_type: "dappnode"
+          network: "%{_ASSETS_NETWORK}"
   - job_name: 'vmagent'
     static_configs:
       - targets: ["localhost:8429"]
         labels:
-          instance: "%{KEYPER_NAME}"
+          instance: "kpr-%{KEYPER_NAME}"
           deployment: "%{_ASSETS_VERSION}"
+          deployment_type: "dappnode"
+          network: "%{_ASSETS_NETWORK}"

--- a/metrics/entrypoint.sh
+++ b/metrics/entrypoint.sh
@@ -62,11 +62,6 @@ source_user_settings() {
     fi
 }
 
-replace_envs_in_yaml() {
-    echo "[INFO | metrics] Replacing environment variables in the configuration file"
-    sed "s|%{KEYPER_NAME}|$KEYPER_NAME|g; s|%{_ASSETS_VERSION}|$_ASSETS_VERSION|g" "$TEMPLATE_CONFIG_FILE" >"$CONFIG_FILE"
-}
-
 update_user_settings
 
 if [ "${SHUTTER_PUSH_METRICS_ENABLED}" = "false" ]; then
@@ -77,8 +72,6 @@ fi
 source_assets_envs
 
 source_user_settings
-
-replace_envs_in_yaml
 
 exec /vmagent-prod \
     -promscrape.config="${CONFIG_FILE}" \

--- a/package_variants/gnosis/docker-compose.yml
+++ b/package_variants/gnosis/docker-compose.yml
@@ -6,14 +6,13 @@ services:
         CHAIN_PORT: 26656
         KEYPER_PORT: 23003
         KEYPER_METRICS_PORT: 9100
+    ports:
+      - "23003:23003"
+      - "26656:26656"
+      - "26660:26660"
+      - "9100:9100"
 
   metrics:
     build:
       args:
         NETWORK: gnosis
-
-    ports:
-      - "23003:23003/tcp"
-      - "26656:26656"
-      - "26660:26660"
-      - "9100:9100"

--- a/shutter/Dockerfile
+++ b/shutter/Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/shutter-network/assets:${ASSETS_VERSION} as assets
 RUN rsync -aq --delete /assets-source/ /assets/
 
 ARG UPSTREAM_VERSION
-FROM ghcr.io/shutter-network/rolling-shutter:${UPSTREAM_VERSION}
+FROM ghcr.io/shutter-network/keyper:${UPSTREAM_VERSION}
 
 ARG NETWORK
 ARG KEYPER_CONFIG_DIR
@@ -23,7 +23,7 @@ RUN apt-get update && \
 ENV SHUTTER_GNOSIS_SM_BLOCKTIME=10 \
     SHUTTER_GNOSIS_GENESIS_KEYPER=0x440Dc6F164e9241F04d282215ceF2780cd0B755e \
     SHUTTER_GNOSIS_MAXTXPOINTERAGE=5 \
-    SHUTTER_DATABASE_URL=postgres://postgres@db.shutter-${NETWORK}.dappnode:5432/keyper \
+    SHUTTER_DATABASEURL=postgres://postgres@db.shutter-${NETWORK}.dappnode:5432/keyper \
     SHUTTER_SHUTTERMINT_SHUTTERMINTURL=http://localhost:26657 \
     CHAIN_LISTEN_PORT=26657 \
     SHUTTER_BIN=/rolling-shutter \

--- a/shutter/Dockerfile
+++ b/shutter/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=assets ${ASSETS_DIR}/ ${ASSETS_DIR}/
 
 # Placed here to rebuild less layers
 ENV CHAIN_PORT=${CHAIN_PORT} \
-    SHUTTER_P2P_LISTENADDRESSES="/ip4/0.0.0.0/tcp/${KEYPER_PORT}" \
+    SHUTTER_P2P_LISTENADDRESSES="/ip4/0.0.0.0/tcp/${KEYPER_PORT},/ip4/0.0.0.0/udp/${KEYPER_PORT}/quic-v1" \
     NETWORK=${NETWORK}
 
 ENTRYPOINT ["supervisord", "-c", "/etc/supervisord.conf"]

--- a/shutter/go-shutter-settings/settings/keyper.go
+++ b/shutter/go-shutter-settings/settings/keyper.go
@@ -8,7 +8,7 @@ import (
 
 type KeyperConfig struct {
 	InstanceID           int    `env:"_ASSETS_INSTANCE_ID"`
-	DatabaseURL          string `env:"SHUTTER_DATABASE_URL"`
+	DatabaseURL          string `env:"SHUTTER_DATABASEURL"`
 	BeaconAPIURL         string `env:"SHUTTER_BEACONAPIURL"`
 	MaxNumKeysPerMessage int    `env:"_ASSETS_MAX_NUM_KEYS_PER_MESSAGE"`
 	Gnosis               struct {
@@ -31,8 +31,8 @@ type KeyperConfig struct {
 	}
 	P2P struct {
 		P2PKey                   string   `env:"SHUTTER_P2P_KEY"`
-		ListenAddresses          string   `env:"SHUTTER_P2P_LISTENADDRESSES"`
-		AdvertiseAddresses       string   `env:"SHUTTER_P2P_ADVERTISEADDRESSES"`
+		ListenAddresses          []string `env:"SHUTTER_P2P_LISTENADDRESSES"`
+		AdvertiseAddresses       []string `env:"SHUTTER_P2P_ADVERTISEADDRESSES"`
 		CustomBootstrapAddresses []string `env:"_ASSETS_CUSTOM_BOOTSTRAP_ADDRESSES"`
 		DiscoveryNamespace       string   `env:"_ASSETS_DISCOVERY_NAME_PREFIX"`
 	}
@@ -44,7 +44,7 @@ type KeyperConfig struct {
 		DKGStartBlockDelta int    `env:"_ASSETS_DKG_START_BLOCK_DELTA"`
 	}
 	Metrics struct {
-		Enabled bool `env:"SHUTTER_ENABLED"`
+		Enabled bool `env:"SHUTTER_METRICS_ENABLED"`
 	}
 }
 

--- a/shutter/scripts/configure.sh
+++ b/shutter/scripts/configure.sh
@@ -31,7 +31,7 @@ init_keyper_db() {
 
     echo "[INFO | configure] Initializing keyper database..."
 
-    $SHUTTER_BIN gnosiskeyper initdb --config "$KEYPER_CONFIG_FILE"
+    $SHUTTER_BIN gnosiskeyper initdb --config "$KEYPER_GENERATED_CONFIG_FILE"
 }
 
 init_chain() {
@@ -73,9 +73,9 @@ check_assets
 
 generate_keyper_config
 
-configure_keyper
-
 init_keyper_db
+
+configure_keyper
 
 init_chain
 

--- a/shutter/scripts/configure.sh
+++ b/shutter/scripts/configure.sh
@@ -31,7 +31,7 @@ init_keyper_db() {
 
     echo "[INFO | configure] Initializing keyper database..."
 
-    $SHUTTER_BIN gnosiskeyper initdb --config "$KEYPER_GENERATED_CONFIG_FILE"
+    $SHUTTER_BIN gnosiskeyper initdb --config "$KEYPER_CONFIG_FILE"
 }
 
 init_chain() {
@@ -73,11 +73,11 @@ check_assets
 
 generate_keyper_config
 
+configure_keyper
+
 init_keyper_db
 
 init_chain
-
-configure_keyper
 
 configure_chain
 

--- a/shutter/scripts/configure_keyper.sh
+++ b/shutter/scripts/configure_keyper.sh
@@ -15,6 +15,7 @@ export SHUTTER_BEACONAPIURL=$(get_beacon_api_url_from_global_env "$NETWORK" "$SU
 export SHUTTER_GNOSIS_NODE_CONTRACTSURL=http://execution.gnosis.dncore.dappnode:8545
 export SHUTTER_GNOSIS_NODE_ETHEREUMURL=$(get_execution_ws_url_from_global_env "$NETWORK" "$SUPPORTED_NETWORKS")
 export VALIDATOR_PUBLIC_KEY=$(cat "${SHUTTER_CHAIN_DIR}/config/priv_validator_pubkey.hex")
+export SHUTTER_METRICS_ENABLED=${SHUTTER_PUSH_METRICS_ENABLED}
 
 echo "[INFO | configure] LISTEN: $SHUTTER_P2P_LISTENADDRESSES"
 

--- a/shutter/scripts/configure_keyper.sh
+++ b/shutter/scripts/configure_keyper.sh
@@ -10,7 +10,7 @@ echo "[INFO | configure] Calculating keyper configuration values..."
 
 SUPPORTED_NETWORKS="gnosis"
 
-export SHUTTER_P2P_ADVERTISEADDRESSES="/ip4/${_DAPPNODE_GLOBAL_PUBLIC_IP}/tcp/${KEYPER_PORT}"
+export SHUTTER_P2P_ADVERTISEADDRESSES="[\"/ip4/${_DAPPNODE_GLOBAL_PUBLIC_IP}/tcp/${KEYPER_PORT}\"]"
 export SHUTTER_BEACONAPIURL=$(get_beacon_api_url_from_global_env "$NETWORK" "$SUPPORTED_NETWORKS")
 export SHUTTER_GNOSIS_NODE_CONTRACTSURL=http://execution.gnosis.dncore.dappnode:8545
 export SHUTTER_GNOSIS_NODE_ETHEREUMURL=$(get_execution_ws_url_from_global_env "$NETWORK" "$SUPPORTED_NETWORKS")

--- a/shutter/scripts/configure_keyper.sh
+++ b/shutter/scripts/configure_keyper.sh
@@ -10,7 +10,12 @@ echo "[INFO | configure] Calculating keyper configuration values..."
 
 SUPPORTED_NETWORKS="gnosis"
 
-export SHUTTER_P2P_ADVERTISEADDRESSES="[\"/ip4/${_DAPPNODE_GLOBAL_PUBLIC_IP}/tcp/${KEYPER_PORT}\"]"
+# Conditionally add square brackets to SHUTTER_P2P_LISTENADDRESSES
+if [[ ! "$SHUTTER_P2P_LISTENADDRESSES" =~ ^\[.*\]$ ]]; then
+    export SHUTTER_P2P_LISTENADDRESSES="[$SHUTTER_P2P_LISTENADDRESSES]"
+fi
+
+export SHUTTER_P2P_ADVERTISEADDRESSES="[\"/ip4/${_DAPPNODE_GLOBAL_PUBLIC_IP}/tcp/${KEYPER_PORT}\", \"/ip4/${_DAPPNODE_GLOBAL_PUBLIC_IP}/udp/${KEYPER_PORT}/quic-v1\"]"
 export SHUTTER_BEACONAPIURL=$(get_beacon_api_url_from_global_env "$NETWORK" "$SUPPORTED_NETWORKS")
 export SHUTTER_GNOSIS_NODE_CONTRACTSURL=http://execution.gnosis.dncore.dappnode:8545
 export SHUTTER_GNOSIS_NODE_ETHEREUMURL=$(get_execution_ws_url_from_global_env "$NETWORK" "$SUPPORTED_NETWORKS")


### PR DESCRIPTION
- added minor changes for the next shutter network release from https://github.com/dappnode/DAppNodePackage-shutter/pull/3
- fixed env name `SHUTTER_DATABASE_URL` to `SHUTTER_DATABASEURL`, as this is how the shutter binary expects it
- fixed SHUTTER_P2P_ADVERTISEADDRESSES declaration

generated shutter package seems to work fine. Logs include:

```
2024/12/10 21:01:08.083551 INF [validatorsyncer.go:109] synced validator registry end-block=34717112 num-discarded-events=0 num-inserted-events=0 num-registrations=0 start-block=34707113
2024/12/10 21:01:15.792494 INF [validatorsyncer.go:109] synced validator registry end-block=34727112 num-discarded-events=0 num-inserted-events=0 num-registrations=0 start-block=34717113
2024/12/10 21:01:19.553712 INF [validatorsyncer.go:109] synced validator registry end-block=34737112 num-discarded-events=0 num-inserted-events=0 num-registrations=0 start-block=34727113
2024/12/10 21:01:22.355993 INF [          app.go:806] persisting state to disk height=188557
2024/12/10 21:01:24.074659 INF [validatorsyncer.go:109] synced validator registry end-block=34747112 num-discarded-events=0 num-inserted-events=0 num-registrations=0 start-block=34737113
2024/12/10 21:01:27.314725 INF [validatorsyncer.go:109] synced validator registry end-block=34757112 num-discarded-events=0 num-inserted-events=0 num-registrations=0 start-block=34747113

```